### PR TITLE
Update requirements.txt - Add GPUtil requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ win10toast
 discord
 asyncio
 openai
+GPUtil


### PR DESCRIPTION
For me, when I was installing, GPUtil was not a requirement but was needed for me to run the code (as it imports GPUtil).
Fixed that problem with a line of code.